### PR TITLE
Add persistence layer and service implementation for products

### DIFF
--- a/MyApp.Application/Interfaces/Persistence/IAppDbContext.cs
+++ b/MyApp.Application/Interfaces/Persistence/IAppDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+using MyApp.Domain.Entities;
+
+namespace MyApp.Application.Interfaces.Persistence;
+
+public interface IAppDbContext
+{
+    DbSet<Product> Products { get; }
+    
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/MyApp.Application/Services/ProductService.cs
+++ b/MyApp.Application/Services/ProductService.cs
@@ -1,72 +1,60 @@
-﻿using MyApp.Application.Interfaces.Services;
+using MyApp.Application.Interfaces.Services;
+using MyApp.Application.Interfaces.Persistence;
 using MyApp.Common.DTOs.Product;
 using MyApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace MyApp.Application.Services;
 
 public class ProductService : IProductService
 {
-    // private readonly AppDbContext _context;
-    //
-    // public ProductService(AppDbContext context)
-    // {
-    //     _context = context;
-    // }
-    //
-    // public async Task<ProductResponse> CreateProductAsync(CreateProductRequest request)
-    // {
-    //     var product = new Product
-    //     {
-    //         Id = Guid.NewGuid(),
-    //         Name = request.Name,
-    //         Description = request.Description,
-    //         Price = request.Price,
-    //         CreatedAt = DateTime.UtcNow
-    //     };
-    //
-    //     await _context.Products.AddAsync(product);
-    //     await _context.SaveChangesAsync();
-    //
-    //     return MapToResponse(product);
-    // }
-    //
-    // public async Task<ProductResponse?> GetProductByIdAsync(Guid id)
-    // {
-    //     var product = await _context.Products.FindAsync(id);
-    //     return product != null ? MapToResponse(product) : null;
-    // }
-    //
-    // public async Task<IEnumerable<ProductResponse>> GetAllProductsAsync()
-    // {
-    //     var products = await _context.Products.ToListAsync();
-    //     return products.Select(MapToResponse);
-    // }
-    //
-    // private static ProductResponse MapToResponse(Product product)
-    // {
-    //     return new ProductResponse
-    //     {
-    //         Id = product.Id,
-    //         Name = product.Name,
-    //         Description = product.Description,
-    //         Price = product.Price,
-    //         CreatedAt = product.CreatedAt,
-    //         UpdatedAt = product.UpdatedAt
-    //     };
-    // }
-
-    public Task<ProductResponse> CreateProductAsync(CreateProductRequest request)
+    private readonly IAppDbContext _context;
+    
+    public ProductService(IAppDbContext context)
     {
-        throw new NotImplementedException();
+        _context = context;
     }
-
-    public Task<ProductResponse?> GetProductByIdAsync(Guid id)
+    
+    public async Task<ProductResponse> CreateProductAsync(CreateProductRequest request)
     {
-        throw new NotImplementedException();
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            Name = request.Name,
+            Description = request.Description,
+            Price = request.Price,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    
+        await _context.Products.AddAsync(product);
+        await _context.SaveChangesAsync();
+    
+        return MapToResponse(product);
     }
-
-    public Task<IEnumerable<ProductResponse>> GetAllProductsAsync()
+    
+    public async Task<ProductResponse?> GetProductByIdAsync(Guid id)
     {
-        throw new NotImplementedException();
+        var product = await _context.Products.FindAsync(id);
+        return product != null ? MapToResponse(product) : null;
+    }
+    
+    public async Task<IEnumerable<ProductResponse>> GetAllProductsAsync()
+    {
+        var products = await _context.Products.ToListAsync();
+        return products.Select(MapToResponse);
+    }
+    
+    private static ProductResponse MapToResponse(Product product)
+    {
+        return new ProductResponse
+        {
+            Id = product.Id,
+            Name = product.Name,
+            Description = product.Description,
+            Price = product.Price,
+            CreatedAt = product.CreatedAt,
+            UpdatedAt = product.UpdatedAt
+        };
     }
 }

--- a/MyApp.Infrastructure/DependencyInjection.cs
+++ b/MyApp.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MyApp.Application.Interfaces.Persistence;
 using MyApp.Application.Interfaces.Services;
 using MyApp.Application.Services;
 using MyApp.Domain.Entities;
@@ -19,6 +20,7 @@ public static class DependencyInjection
         var connectionString = config.GetConnectionString("DefaultConnection");
 
         services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
+        services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
 
         services
             .AddIdentity<AppUser, IdentityRole<Guid>>(options =>
@@ -33,6 +35,7 @@ public static class DependencyInjection
             .AddDefaultTokenProviders();
 
         services.AddScoped<IAuthService, AuthService>();
+        services.AddScoped<IProductService, ProductService>();
 
         return services;
     }

--- a/MyApp.Infrastructure/MyApp.Infrastructure.csproj
+++ b/MyApp.Infrastructure/MyApp.Infrastructure.csproj
@@ -10,10 +10,6 @@
 	  <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Repos\Services\" />
-	</ItemGroup>
-
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/MyApp.Infrastructure/Persistence/AppDbContext.cs
+++ b/MyApp.Infrastructure/Persistence/AppDbContext.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using MyApp.Application.Interfaces.Persistence;
 using MyApp.Domain.Entities;
 
 namespace MyApp.Infrastructure.Persistence;
 
-public class AppDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>
+public class AppDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>, IAppDbContext
 {
     public DbSet<Product> Products { get; set; } = null!;
     public AppDbContext(DbContextOptions<AppDbContext> options)

--- a/MyApp.Infrastructure/Repos/Interfaces/IProductRepository.cs
+++ b/MyApp.Infrastructure/Repos/Interfaces/IProductRepository.cs
@@ -1,6 +1,11 @@
-﻿namespace MyApp.Infrastructure.Repos.Interfaces;
+﻿using MyApp.Domain.Entities;
 
-public class IProductRepository
+namespace MyApp.Infrastructure.Repos.Interfaces;
+
+public interface IProductRepository
 {
-    
+    Task<Product> CreateAsync(Product product);
+    Task<Product?> GetByIdAsync(Guid id);
+    Task<IEnumerable<Product>> GetAllAsync();
+
 }

--- a/MyApp.Infrastructure/Repos/Services/ProductRepository.cs
+++ b/MyApp.Infrastructure/Repos/Services/ProductRepository.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore;
+using MyApp.Domain.Entities;
+using MyApp.Infrastructure.Persistence;
+using MyApp.Infrastructure.Repos.Interfaces;
+
+namespace MyApp.Infrastructure.Repos.Services;
+
+public class ProductRepository: IProductRepository
+{
+    private readonly AppDbContext _context;
+
+    public ProductRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Product> CreateAsync(Product product)
+    {
+        await _context.Products.AddAsync(product);
+        await _context.SaveChangesAsync();
+        return product;
+    }
+
+    public async Task<Product?> GetByIdAsync(Guid id)
+    {
+        return await _context.Products.FindAsync(id);
+    }
+
+    public async Task<IEnumerable<Product>> GetAllAsync()
+    {
+        return await _context.Products.ToListAsync();
+    }
+}


### PR DESCRIPTION
Introduced `IAppDbContext` abstraction and integrated it with `AppDbContext`. Implemented `ProductService` and `ProductRepository` to handle product operations. Registered the respective services and interfaces in the dependency injection container.